### PR TITLE
improve filter values in queryParams

### DIFF
--- a/addon/controllers/index.js
+++ b/addon/controllers/index.js
@@ -7,17 +7,21 @@ import { inject as service } from '@ember/service';
 export default class IndexController extends Controller {
   @service store;
 
-  sort = '-created';
   size = 15;
 
+  @tracked sort = '-created';
   @tracked page = 0;
   @tracked creatorValue = "";
   @tracked operationValue = "";
+
+  queryParams = ['creatorValue', 'operationValue'];
 
   @action
     resetFilter(){
       this.creatorValue = "";
       this.operationValue = "";
+      this.sort = '-created';
+      this.page = 0;
       this.updateSearch.perform();
     }
 

--- a/addon/routes/index.js
+++ b/addon/routes/index.js
@@ -7,9 +7,19 @@ export default class IndexRoute extends Route.extend(DataTableRouteMixin) {
   modelName = 'job';
 
   mergeQueryOptions(param) {
-    return {
-      sort: param.sort
+    const query = {
+      sort: param.sort,
     };
+
+    if (param.creatorValue) {
+      query['filter[creator]'] = param.creatorValue;
+    }
+
+    if (param.operationValue) {
+      query['filter[operation]'] = param.operationValue;
+    }
+
+    return query;
   }
 }
 


### PR DESCRIPTION
-Add filtering values to queryParam
- When filtering and then changing sorting in datatable, the filtering values would be ignored. Now they are set properly in request to backend when sorting through datatable