### PR TITLE
Update the date-fns format import path

### DIFF
--- a/addon/helpers/format-date.js
+++ b/addon/helpers/format-date.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { format } from 'date-fns';
+import format from 'date-fns/format';
 
 export default helper(function formatDate([datetime, formatString]) {
   if (!(datetime instanceof Date)) return '';


### PR DESCRIPTION
There is a bug in the current ember-auto-import implementation which prevents treeshaking the date-fns library if the top level path is used. We can bypass that issue by importing from the `date-fns/format` path instead.

This reduces the bundle size quite a bit:

Before:
 - dist/assets/chunk.649.861edceee072c31e03e1.js: 190.18 KB (46.84 KB gzipped)

After:
 - dist/assets/chunk.283.d01b1f92c9b882cabe30.js: 116.3 KB (31.51 KB gzipped)