### PR TITLE
Drop Appuniversum v1 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@appuniversum/ember-appuniversum": "^1.10.0 || ^2.0.0",
+        "@appuniversum/ember-appuniversum": "^2.18.0",
         "@ember/legacy-built-in-components": "^0.4.1",
         "date-fns": "^2.28.0",
         "ember-auto-import": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "release": "release-it"
   },
   "dependencies": {
-    "@appuniversum/ember-appuniversum": "^1.10.0 || ^2.0.0",
+    "@appuniversum/ember-appuniversum": "^2.18.0",
     "@ember/legacy-built-in-components": "^0.4.1",
     "date-fns": "^2.28.0",
     "ember-auto-import": "^2.6.3",


### PR DESCRIPTION
This allows us to resolve all v2 deprecations and add support for Appuniversum v3.