### PR TITLE
Drop support for old Ember versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ The ember-jobs-dashboard-engine is the engine version of [frontend-harvesting-se
 
 ## Compatibility
 
-* Ember.js v3.28 or above
-* Ember CLI v3.28 or above
+* Ember.js v4.12 or above
+* Ember CLI v4.12 or above
 * Node.js v18 or above
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
       },
       "peerDependencies": {
         "ember-engines": "^0.8.14",
-        "ember-source": "^3.28.0 || ^4.0.0"
+        "ember-source": "^4.12.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "peerDependencies": {
     "ember-engines": "^0.8.14",
-    "ember-source": "^3.28.0 || ^4.0.0"
+    "ember-source": "^4.12.0"
   },
   "engines": {
     "node": "18.* || >= 20"

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -7,22 +7,6 @@ module.exports = async function () {
   return {
     scenarios: [
       {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-4.8',
-        npm: {
-          devDependencies: {
-            'ember-source': '~4.8.0',
-          },
-        },
-      },
-      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
This bumps the required ember-source version to 4.12.0.