### PR TITLE
Fix some issues in the delete flow

### DIFF
--- a/addon/controllers/details.js
+++ b/addon/controllers/details.js
@@ -13,54 +13,62 @@ export default class DetailsController extends Controller {
 
     //NOTE: Even though inputContainers & resultsContainers have the same nested structure, I duplicated the code since I know you like the seperation more then a wrapping |for| loop
     const tasks = yield job.tasks;
-    yield job.destroyRecord();
 
-    for (let task of tasks.toArray()) {
+    for (let task of tasks.slice()) {
       const iContainers = yield task.inputContainers;
       const rContainers = yield task.resultsContainers;
-      yield task.destroyRecord();
 
-      for (let input of iContainers.toArray()) {
+      for (let input of iContainers.slice()) {
         const fileList = yield input.files;
         const collectionList = yield input.harvestingCollections;
-        yield input.destroyRecord();
 
-        for (let file of fileList.toArray()) {
+        for (let file of fileList.slice()) {
           //NOTE: file model gets found but cannot get physical file in backend to delete
           yield file.destroyRecord();
         }
 
-        for (let collection of collectionList.toArray()) {
+        for (let collection of collectionList.slice()) {
           const rObjs = yield collection.remoteDataObjects;
-          yield collection.destroyRecord();
 
-          for (let rObj of rObjs.toArray()) {
+          for (let rObj of rObjs.slice()) {
             yield rObj.destroyRecord();
           }
+
+          yield collection.destroyRecord();
         }
+
+        yield input.destroyRecord();
       }
 
-      for (let result of rContainers.toArray()) {
+      for (let result of rContainers.slice()) {
         const fileList = yield result.files;
         const collectionList = yield result.harvestingCollections;
-        yield result.destroyRecord();
 
-        for (let file of fileList.toArray()) {
+        for (let file of fileList.slice()) {
           //NOTE: file model gets found but cannot get physical file in backend to delete
           yield file.destroyRecord();
         }
 
-        for (let collection of collectionList.toArray()) {
+        for (let collection of collectionList.slice()) {
           const rObjs = yield collection.remoteDataObjects;
-          yield collection.destroyRecord();
 
           //NOTE: Pretty sure this should get deleted after the file issue is resolved
-          for (let rObj of rObjs.toArray()) {
+          for (let rObj of rObjs.slice()) {
             yield rObj.destroyRecord();
           }
+
+          yield collection.destroyRecord();
         }
+
+        yield result.destroyRecord();
       }
-      this.transitionToRoute('index');
+
+      yield task.destroyRecord();
     }
+
+    yield job.destroyRecord();
+
+    // TODO: switch to the router service, but that requires more work in engines since it doesn't share the service by default.
+    this.transitionToRoute('index');
   }
 }


### PR DESCRIPTION
Deleting jobs had some issues on newer EmberData versions. Copying relationship data and accessing it after the original record is deleted causes exceptions. To work around this we delete the related records before the original record.