### PR TITLE
Update to ember-engines v0.11

### DIFF
--- a/addon/controllers/details.js
+++ b/addon/controllers/details.js
@@ -1,8 +1,10 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
+import { service } from '@ember/service';
 
 export default class DetailsController extends Controller {
+  @service router;
   @tracked page = 0;
   @tracked sort = 'created';
   @tracked size = 15;
@@ -68,7 +70,6 @@ export default class DetailsController extends Controller {
 
     yield job.destroyRecord();
 
-    // TODO: switch to the router service, but that requires more work in engines since it doesn't share the service by default.
-    this.transitionToRoute('index');
+    this.router.transitionTo('index');
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "ember-cli-htmlbars": "^6.2.0",
         "ember-concurrency": "^3.0.0 || ^4.0.0",
         "ember-data-table": "^2.1.0",
+        "ember-engines-router-service": "^0.6.0",
         "ember-intl": "^5.7.2 || ^6.1.0"
       },
       "devDependencies": {
@@ -37,7 +38,7 @@
         "ember-cli-sri": "^2.1.1",
         "ember-cli-terser": "^4.0.2",
         "ember-data": "~4.12.0",
-        "ember-engines": "^0.9.0",
+        "ember-engines": "^0.11.0",
         "ember-load-initializers": "^2.1.2",
         "ember-page-title": "^7.0.0",
         "ember-qunit": "^6.2.0",
@@ -69,8 +70,8 @@
         "node": "18.* || >= 20"
       },
       "peerDependencies": {
-        "ember-engines": "^0.9.0",
-        "ember-source": "^4.12.0"
+        "ember-engines": "^0.11.0",
+        "ember-source": "^4.12.0 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3442,15 +3443,15 @@
       }
     },
     "node_modules/@embroider/macros": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.15.1.tgz",
-      "integrity": "sha512-l6rv4UVyQ+0XZbabpGXXUNpm7vMEVFzFwWnBeyKFLmmxuEQ4tgxEgR9qDRF/IWJXGS6na6pXN3jTk/cOaQiCpw==",
+      "version": "1.16.12",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.16.12.tgz",
+      "integrity": "sha512-cgaEbzCvUOZF7Xs9FNMGknSCTgE01A1cXkkEhSTuaPbf6F/2z9pZAdQpVrBbTvo1Sg8CwMsm+piahjy43KoGuA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.24.0",
-        "@embroider/shared-internals": "2.6.0",
+        "@embroider/shared-internals": "2.9.0",
         "assert-never": "^1.2.1",
         "babel-import-util": "^2.0.0",
-        "ember-cli-babel": "^8.2.0",
+        "ember-cli-babel": "^7.26.6",
         "find-up": "^5.0.0",
         "lodash": "^4.17.21",
         "resolve": "^1.20.0",
@@ -3469,17 +3470,20 @@
       }
     },
     "node_modules/@embroider/macros/node_modules/@embroider/shared-internals": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.6.0.tgz",
-      "integrity": "sha512-A2BYQkhotdKOXuTaxvo9dqOIMbk+2LqFyqvfaaePkZcFJvtCkvTaD31/sSzqvRF6rdeBHjdMwU9Z2baPZ55fEQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.9.0.tgz",
+      "integrity": "sha512-8untWEvGy6av/oYibqZWMz/yB+LHsKxEOoUZiLvcpFwWj2Sipc0DcXeTJQZQZ++otNkLCWyDrDhOLrOkgjOPSg==",
+      "license": "MIT",
       "dependencies": {
         "babel-import-util": "^2.0.0",
         "debug": "^4.3.2",
         "ember-rfc176-data": "^0.3.17",
         "fs-extra": "^9.1.0",
+        "is-subdir": "^1.2.0",
         "js-string-escape": "^1.0.1",
         "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
+        "pkg-entry-points": "^1.1.0",
         "resolve-package-path": "^4.0.1",
         "semver": "^7.3.5",
         "typescript-memoize": "^1.0.1"
@@ -3488,344 +3492,13 @@
         "node": "12.* || 14.* || >= 16"
       }
     },
-    "node_modules/@embroider/macros/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
     "node_modules/@embroider/macros/node_modules/babel-import-util": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.2.tgz",
-      "integrity": "sha512-pR4vWlVujmYENFbceYcLPYCD+ulYGfmNmbTVd6Xp49d0uk+K3sWy6+O+5RLEa0OonXw9rf3hc9xFmglFnS0MWg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.1.1.tgz",
+      "integrity": "sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12.*"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/babel-plugin-module-resolver": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.0.tgz",
-      "integrity": "sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==",
-      "dependencies": {
-        "find-babel-config": "^2.0.0",
-        "glob": "^8.0.3",
-        "pkg-up": "^3.1.0",
-        "reselect": "^4.1.7",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/broccoli-babel-transpiler": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-8.0.0.tgz",
-      "integrity": "sha512-3HEp3flvasUKJGWERcrPgM1SWvHJ0O/fmbEtY9L4kDyMSnqjY6hTYvNvgWCIgbwXAYAUlZP0vjAQsmyLNGLwFw==",
-      "dependencies": {
-        "broccoli-persistent-filter": "^3.0.0",
-        "clone": "^2.1.2",
-        "hash-for-dep": "^1.4.7",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.9",
-        "json-stable-stringify": "^1.0.1",
-        "rsvp": "^4.8.4",
-        "workerpool": "^6.0.2"
-      },
-      "engines": {
-        "node": "16.* || >= 18"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.17.9"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/broccoli-plugin/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/editions/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/ember-cli-babel": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-8.2.0.tgz",
-      "integrity": "sha512-8H4+jQElCDo6tA7CamksE66NqBXWs7VNpS3a738L9pZCjg2kXIX4zoyHzkORUqCtr0Au7YsCnrlAMi1v2ALo7A==",
-      "dependencies": {
-        "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/plugin-proposal-class-properties": "^7.16.5",
-        "@babel/plugin-proposal-decorators": "^7.20.13",
-        "@babel/plugin-proposal-private-methods": "^7.16.5",
-        "@babel/plugin-proposal-private-property-in-object": "^7.20.5",
-        "@babel/plugin-transform-class-static-block": "^7.22.11",
-        "@babel/plugin-transform-modules-amd": "^7.20.11",
-        "@babel/plugin-transform-runtime": "^7.13.9",
-        "@babel/plugin-transform-typescript": "^7.20.13",
-        "@babel/preset-env": "^7.20.2",
-        "@babel/runtime": "7.12.18",
-        "amd-name-resolver": "^1.3.1",
-        "babel-plugin-debug-macros": "^0.3.4",
-        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
-        "babel-plugin-module-resolver": "^5.0.0",
-        "broccoli-babel-transpiler": "^8.0.0",
-        "broccoli-debug": "^0.6.4",
-        "broccoli-funnel": "^3.0.8",
-        "broccoli-source": "^3.0.1",
-        "calculate-cache-key-for-tree": "^2.0.0",
-        "clone": "^2.1.2",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "ensure-posix-path": "^1.0.2",
-        "resolve-package-path": "^4.0.3",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": "16.* || 18.* || >= 20"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.12.0"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/find-babel-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.0.0.tgz",
-      "integrity": "sha512-dOKT7jvF3hGzlW60Gc3ONox/0rRZ/tz7WCil0bqA1In/3I8f1BctpXahRnEKDySZqci7u+dqq93sZST9fOJpFw==",
-      "dependencies": {
-        "json5": "^2.1.1",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@embroider/macros/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@embroider/shared-internals": {
@@ -7204,6 +6877,18 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
+    },
+    "node_modules/better-path-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-windows": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -15370,12 +15055,14 @@
       }
     },
     "node_modules/ember-engines": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/ember-engines/-/ember-engines-0.9.0.tgz",
-      "integrity": "sha512-LVb1GrLGU2DXLXL2ynYXPHg0JJ6P3LRciOdDfjP0aRPLZ1evOr0h7IPIDq4SsT2nG0yhX5qBMJNB4NCyFZvcyA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/ember-engines/-/ember-engines-0.11.0.tgz",
+      "integrity": "sha512-AfIuttjI2O5vtx7JkTQwmb2jHeuPJxivha+867NVNyyNobT6HnwqFJQ2Q2kfwaj4qdqAIIzs5uFsjOBNXUAOiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@embroider/macros": "^1.3.0",
+        "@babel/core": "^7.24.4",
+        "@embroider/macros": "^1.16.1",
         "amd-name-resolver": "1.3.1",
         "babel-plugin-compact-reexports": "^1.1.0",
         "broccoli-babel-transpiler": "^7.2.0",
@@ -15387,23 +15074,37 @@
         "broccoli-merge-trees": "^4.2.0",
         "calculate-cache-key-for-tree": "^2.0.0",
         "ember-asset-loader": "^1.0.0",
-        "ember-cli-babel": "^7.18.0",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.3.0",
         "ember-cli-preprocess-registry": "^3.3.0",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-version-checker": "^5.1.2",
         "lodash": "^4.17.11"
       },
       "engines": {
-        "node": "14.* || 16.* || >= 18"
+        "node": "16.* || 18.* || >= 20"
       },
       "peerDependencies": {
-        "@ember/legacy-built-in-components": "*",
-        "ember-source": "^3.24.1 || 4"
+        "ember-engines-router-service": ">=0.5.0",
+        "ember-source": "^3.28 || >= 4.0.0"
       },
       "peerDependenciesMeta": {
-        "@ember/legacy-built-in-components": {
+        "ember-engines-router-service": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ember-engines-router-service": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ember-engines-router-service/-/ember-engines-router-service-0.6.0.tgz",
+      "integrity": "sha512-c8Q0l1LKfeZvVsyQtCI52UvftV6jm5D9xYtzffgBKUp2/sm0/EuzQtyfskwRpg3NGQ+wKJaMnQX04VpMlIIeHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.8.4",
+        "@embroider/macros": "^1.13.2"
+      },
+      "peerDependencies": {
+        "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/ember-engines/node_modules/broccoli-merge-trees": {
@@ -22597,6 +22298,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-subdir": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+      "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "better-path-resolve": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-symbol": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
@@ -26785,6 +26498,15 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkg-entry-points": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-entry-points/-/pkg-entry-points-1.1.1.tgz",
+      "integrity": "sha512-BhZa7iaPmB4b3vKIACoppyUoYn8/sFs17VJJtzrzPZvEnN2nqrgg911tdL65lA2m1ml6UI3iPeYbZQ4VXpn1mA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/pkg-entry-points?sponsor=1"
       }
     },
     "node_modules/pkg-up": {

--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
   },
   "dependencies": {
     "@appuniversum/ember-appuniversum": "^2.18.0 || ^3.0.0",
-    "@ember/legacy-built-in-components": "^0.5.0",
     "date-fns": "^2.28.0",
     "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.2.0",
     "ember-concurrency": "^3.0.0 || ^4.0.0",
     "ember-data-table": "^2.1.0",
+    "ember-engines-router-service": "^0.6.0",
     "ember-intl": "^5.7.2 || ^6.1.0"
   },
   "devDependencies": {
@@ -64,7 +64,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-data": "~4.12.0",
-    "ember-engines": "^0.9.0",
+    "ember-engines": "^0.11.0",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.2.0",
@@ -93,8 +93,8 @@
     "webpack": "^5.78.0"
   },
   "peerDependencies": {
-    "ember-engines": "^0.9.0",
-    "ember-source": "^4.12.0"
+    "ember-engines": "^0.11.0",
+    "ember-source": "^4.12.0 || ^5.0.0 || ^6.0.0"
   },
   "engines": {
     "node": "18.* || >= 20"


### PR DESCRIPTION
This also adds support for Ember v5+.

Breaking since it also updates the peerDependency.